### PR TITLE
add sound playback

### DIFF
--- a/chords/index.html
+++ b/chords/index.html
@@ -82,6 +82,7 @@
 			<label><input type="checkbox" id="showKeyboard" checked>Show Keyboard</label><br>
 			<label><input type="checkbox" id="highlightCorrectKeys">Show Correct Keys After 3s</label><br>
 			<label><input type="checkbox" id="sendMidiNotes">Play Answer Notes over MIDI (for guessing from sound)</label><br>
+			<label><input type="checkbox" id="playNoteSounds" checked>Play Sounds When Notes Are Pressed</label><br>
 		</details>
 
 		<details class="midiCollapsible">

--- a/chords/scripts.js
+++ b/chords/scripts.js
@@ -10,19 +10,71 @@ let currentIndex = 0;
 let keyIndex = 0;
 let keys = [];
 
-
 let highlightTimer; 
 
+let audioContext;
+let oscillators = {};
+
+function initAudioContext() {
+	audioContext = new (window.AudioContext || window.webkitAudioContext)();
+}
+
+function playNote(noteNumber) {
+	if (!audioContext) {
+		initAudioContext();
+	}
+	
+	if (!document.getElementById('playNoteSounds').checked) {
+		return;
+	}
+	
+	const frequency = 440 * Math.pow(2, (noteNumber - 69) / 12);
+	
+	const oscillator = audioContext.createOscillator();
+	const gainNode = audioContext.createGain();
+	
+	oscillator.type = 'sine';
+	oscillator.frequency.value = frequency;
+	
+	gainNode.gain.value = 0.3;
+	
+	oscillator.connect(gainNode);
+	gainNode.connect(audioContext.destination);
+	
+	oscillator.start();
+	oscillators[noteNumber] = { oscillator, gainNode };
+	
+	gainNode.gain.setValueAtTime(gainNode.gain.value, audioContext.currentTime);
+	gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 1.5);
+	
+	oscillator.stop(audioContext.currentTime + 1.5);
+	
+	oscillator.onended = function() {
+		delete oscillators[noteNumber];
+	};
+}
+
+function stopNote(noteNumber) {
+	if (oscillators[noteNumber]) {
+		const { gainNode } = oscillators[noteNumber];
+		gainNode.gain.setValueAtTime(gainNode.gain.value, audioContext.currentTime);
+		gainNode.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.1);
+		setTimeout(() => {
+			if (oscillators[noteNumber]) {
+				oscillators[noteNumber].oscillator.stop();
+				delete oscillators[noteNumber];
+			}
+		}, 100);
+	}
+}
 
 function isIntervalChord(chord) {
 	return chord.match(/^(#|b|B)?[iIvV]{1,3}.*/);
 }
 
-
 function isNamedChord(chord) {
 	return chord.match(/^[A-G](#|b)?/);
 }
-
 
 function generateNotesFromChordName(chordName) {
 	let rootNotePattern = /^[A-G](#|b)?/; // Matches the root note
@@ -97,7 +149,6 @@ function setRandomChord()
 	} while (currentChordName === lastChordName && selectedChordTypes.length > 1 && keys.length > 1);
 }
 
-
 function handleKeyClick(key)
 {
 	if (activeKeys.includes(key)) {
@@ -109,12 +160,12 @@ function handleKeyClick(key)
 	checkChord();
 }
 
-
 function handleKeyPressed(key)
 {
 	let keyElement = document.querySelector(`.key[data-note="${key}"]`);
 
 	activeKeys.push(key);
+    playNote(parseInt(key));
 
 	if (getSortedAnswerNotes().includes(key % 12)) {
 		keyElement.classList.add('correct');
@@ -125,16 +176,15 @@ function handleKeyPressed(key)
 	}
 }
 
-
 function handleKeyReleased(key)
 {
 	let keyElement = document.querySelector(`.key[data-note="${key}"]`);
 
 	activeKeys.splice(activeKeys.indexOf(key), 1);
+    stopNote(parseInt(key));
 
 	keyElement.classList.remove('correct', 'incorrect');
 }
-
 
 function handleMidiMessage(midiMessage)
 {
@@ -156,7 +206,6 @@ function handleMidiMessage(midiMessage)
 	}
 }
 
-
 function sendMidiNote(note, velocity, time)
 {
 	// Send a MIDI message to the first available MIDI output
@@ -172,6 +221,13 @@ function sendMidiNote(note, velocity, time)
 			}
 		});
 	}
+    
+    if (document.getElementById('playNoteSounds').checked) {
+        playNote(note + 48);
+        setTimeout(() => {
+            stopNote(note + 48);
+        }, time);
+    }
 }
 
 // Returns the current chord notes wrapped around the octave and sorted
@@ -262,7 +318,6 @@ function checkChord() {
 	}
 }
 
-
 function highlightCorrectKeys() {
 	// Clear previous highlights
 	document.querySelectorAll('.key.highlight').forEach(key => key.classList.remove('highlight'));
@@ -279,7 +334,6 @@ function highlightCorrectKeys() {
 		});
 	}, 3000);  // 3 seconds
 }
-
 
 function onMIDISuccess(midiAccess)
 {
@@ -304,13 +358,11 @@ function onMIDISuccess(midiAccess)
 	});
 }
 
-
 function onMIDIFailure(error)
 {
 	document.getElementById("midiStatusText").textContent = "Failed to get MIDI access. Error: " + error;
 }
 
-	
 function initMIDI()
 {
 	// Initialize MIDI access
@@ -320,7 +372,6 @@ function initMIDI()
 		document.getElementById("midiStatusText").textContent = "Your browser does not support MIDI access. Please ensure you are using a browser that supports WebMIDI, and that you are accessing this site from HTTPS, as some browsers require secure connections for WebMIDI."
 
 }
-
 
 function updateAvailableKeys()
 {
@@ -338,7 +389,6 @@ function updateAvailableKeys()
 		}
 	}
 }
-
 
 function nextKey()
 {
@@ -564,7 +614,6 @@ function getIntervalChordNotesAndName(key, degree, wrap = true)
 	];
 }
 
-
 function generateProgression()
 {
 	currentKeySpan.textContent = keys[keyIndex];
@@ -659,10 +708,8 @@ function generateProgression()
 	}
 }
 
-
 hideProgressionChordNamesCheckbox.addEventListener('change', updateDisplay);
 hideProgressionChordNumerals.addEventListener('change', updateDisplay);
-
 
 function nextProgression()
 {

--- a/chords/ui.js
+++ b/chords/ui.js
@@ -387,6 +387,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	initScales();
 	initJazzBricks();
 	initMIDI();
+	initAudioContext();
 });
 
 document.getElementById('btnResetStats').addEventListener('click', () => {
@@ -401,3 +402,16 @@ document.getElementById('btnResetStats').addEventListener('click', () => {
 	cntDegreesIncorrect.textContent = "0";
 	cntBricksIncorrect.textContent = "0";
 });
+
+document.getElementById('playNoteSounds').addEventListener('change', function() {
+    if (this.checked && !audioContext) {
+        initAudioContext();
+    }
+});
+
+// User interaction is required to start audio context in some browsers
+document.addEventListener('click', function() {
+    if (audioContext && audioContext.state === 'suspended') {
+        audioContext.resume();
+    }
+}, { once: true });


### PR DESCRIPTION
This pull request introduces a new feature that enables playing sound for notes when they are pressed, enhancing the user experience in the chord training application. Key changes include adding a checkbox to toggle sound playback, implementing audio playback functionality, and ensuring compatibility with user interactions required by some browsers.

### User Interface Enhancements:
* Added a new checkbox, `Play Sounds When Notes Are Pressed`, to the settings in `chords/index.html`, allowing users to enable or disable sound playback for note presses.

### Audio Playback Functionality:
* Implemented `initAudioContext`, `playNote`, and `stopNote` functions in `chords/scripts.js` to manage audio playback using the Web Audio API. These functions handle the creation and cleanup of oscillators for playing note sounds.
* Integrated sound playback into the `handleKeyPressed`, `handleKeyReleased`, and `sendMidiNote` functions to ensure notes play and stop appropriately during interactions. [[1]](diffhunk://#diff-470d5a4eaf1dbc6cd3374ea438037077abe8f6ba781e5bf966bc487029440f08L112-R168) [[2]](diffhunk://#diff-470d5a4eaf1dbc6cd3374ea438037077abe8f6ba781e5bf966bc487029440f08L128-L138) [[3]](diffhunk://#diff-470d5a4eaf1dbc6cd3374ea438037077abe8f6ba781e5bf966bc487029440f08R224-R230)

### Browser Compatibility:
* Updated `chords/ui.js` to initialize the audio context on page load and resume it on the first user interaction, addressing browser restrictions on autoplay audio. [[1]](diffhunk://#diff-45776c188ac0fc6146d0c20e9ccf4b6a538d53331630c4f2330cb33164395b27R390) [[2]](diffhunk://#diff-45776c188ac0fc6146d0c20e9ccf4b6a538d53331630c4f2330cb33164395b27R405-R417)